### PR TITLE
Add hybrid stream

### DIFF
--- a/src/Hst.Core.Tests/IOTests/GivenHybridStreamWithDataLessThanSizeThresholdInFirstStream.cs
+++ b/src/Hst.Core.Tests/IOTests/GivenHybridStreamWithDataLessThanSizeThresholdInFirstStream.cs
@@ -1,0 +1,118 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Hst.Core.IO;
+using Xunit;
+
+namespace Hst.Core.Tests.IOTests;
+
+public class GivenHybridStreamWithDataLessThanSizeThresholdInFirstStream
+{
+    [Fact]
+    public async Task When_WritingDataLessThenSizeThreshold_Then_OnlyFirstStreamIsUsed()
+    {
+        // arrange - hybrid stream with size threshold
+        const int sizeThreshold = 1024;
+        using var firstStream = new MemoryStream();
+        using var secondStream = new MemoryStream();
+        await using var hybridStream = new HybridStream(firstStream, secondStream, new HybridStreamOptions
+        {
+            SizeThreshold = sizeThreshold
+        });
+        
+        // arrange - data flushed event args
+        HybridStream.DataFlushedEventArgs dataFlushedEventArgs = null;
+        hybridStream.DataFlushed += (_, e) => dataFlushedEventArgs = e;
+        
+        // arrange - data 1 of 800 bytes to write
+        var data1 = new byte[800];
+        Array.Fill<byte>(data1, 1);
+
+        // arrange - data 2 of 200 bytes to write
+        var data2 = new byte[200];
+        Array.Fill<byte>(data2, 2);
+
+        // arrange - write data 1 to first stream
+        await firstStream.WriteAsync(data1);
+        
+        // act - write data 2 to hybrid stream below size threshold not triggering flush to second stream
+        await hybridStream.WriteAsync(data2);
+        
+        // assert - data flushed event args is null as size threshold not reached by hybrid stream
+        Assert.Null(dataFlushedEventArgs);
+
+        // assert - first stream has data 1 and data 2
+        Assert.Equal(1000, firstStream.Length);
+        var firstStreamData = new byte[1000];
+        firstStream.Position = 0;
+        await firstStream.ReadExactlyAsync(firstStreamData);
+        Assert.Equal(data1.Concat(data2), firstStreamData);
+        
+        // assert - second stream has no data
+        Assert.Equal(0, secondStream.Length);
+
+        // assert - hybrid stream has data 1 and data 2
+        Assert.Equal(1000, hybridStream.Length);
+        var hybridStreamData = new byte[1000];
+        hybridStream.Position = 0;
+        await hybridStream.ReadExactlyAsync(hybridStreamData);
+        Assert.Equal(data1.Concat(data2), hybridStreamData);
+    }
+
+    [Fact]
+    public async Task When_WritingDataMoreThenSizeThreshold_Then_FirstStreamIsFlushToSecondStream()
+    {
+        // arrange - hybrid stream with size threshold
+        const int sizeThreshold = 1024;
+        using var firstStream = new MemoryStream();
+        using var secondStream = new MemoryStream();
+        await using var hybridStream = new HybridStream(firstStream, secondStream, new HybridStreamOptions
+        {
+            SizeThreshold = sizeThreshold
+        });
+
+        // arrange - data flushed event args
+        HybridStream.DataFlushedEventArgs dataFlushedEventArgs = null;
+        hybridStream.DataFlushed += (_, e) => dataFlushedEventArgs = e;
+        
+        // arrange - data 1 of 800 bytes to write
+        var data1 = new byte[800];
+        Array.Fill<byte>(data1, 1);
+
+        // arrange - data 2 of 800 bytes to write
+        var data2 = new byte[800];
+        Array.Fill<byte>(data2, 2);
+        
+        // arrange - write data 1 to first stream
+        await firstStream.WriteAsync(data1);
+        
+        // act - write data 2 to hybrid stream reaching size threshold and triggers flush to second stream
+        await hybridStream.WriteAsync(data2);
+        
+        // assert - data flushed event args bytes total is 800 from flush of first stream to second stream
+        Assert.NotNull(dataFlushedEventArgs);
+        Assert.Equal(800, dataFlushedEventArgs.BytesTotal);
+        
+        // assert - first stream has data 1
+        Assert.Equal(800, firstStream.Length);
+        var firstStreamData = new byte[800];
+        firstStream.Position = 0;
+        await firstStream.ReadExactlyAsync(firstStreamData);
+        Assert.Equal(data1, firstStreamData);
+        
+        // assert - second stream has data 1 written to first stream flushed to second stream with data 2
+        Assert.Equal(1600, secondStream.Length);
+        var secondStreamData = new byte[1600];
+        secondStream.Position = 0;
+        await secondStream.ReadExactlyAsync(secondStreamData);
+        Assert.Equal(data1.Concat(data2), secondStreamData);
+        
+        // assert - hybrid stream has data 1 and data 2
+        Assert.Equal(1600, hybridStream.Length);
+        var hybridStreamData = new byte[1600];
+        hybridStream.Position = 0;
+        await hybridStream.ReadExactlyAsync(hybridStreamData);
+        Assert.Equal(data1.Concat(data2), hybridStreamData);
+    }
+}

--- a/src/Hst.Core.Tests/IOTests/GivenHybridStreamWithEmptyFirstStream.cs
+++ b/src/Hst.Core.Tests/IOTests/GivenHybridStreamWithEmptyFirstStream.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Hst.Core.IO;
+using Xunit;
+
+namespace Hst.Core.Tests.IOTests;
+
+public class GivenHybridStreamWithEmptyFirstStream
+{
+    [Fact]
+    public async Task When_WritingDataLessThenSizeThreshold_Then_OnlyFirstStreamIsUsed()
+    {
+        // arrange - hybrid stream with size threshold
+        const int sizeThreshold = 1024;
+        using var firstStream = new MemoryStream();
+        using var secondStream = new MemoryStream();
+        await using var hybridStream = new HybridStream(firstStream, secondStream, new HybridStreamOptions
+        {
+            SizeThreshold = sizeThreshold
+        });
+
+        // arrange - data flushed event args
+        HybridStream.DataFlushedEventArgs dataFlushedEventArgs = null;
+        hybridStream.DataFlushed += (_, e) => dataFlushedEventArgs = e;
+
+        // arrange - data of 512 bytes to write
+        var data = new byte[512];
+        Array.Fill<byte>(data, 1);
+        
+        // act - write data 1 less than size threshold
+        await hybridStream.WriteAsync(data);
+        
+        // assert - data flushed event args is null as size threshold not reached by hybrid stream
+        Assert.Null(dataFlushedEventArgs);
+
+        // assert - first stream has data
+        Assert.Equal(512, firstStream.Length);
+        
+        // assert - second stream is empty
+        Assert.Equal(0, secondStream.Length);
+        
+        // assert - hybrid stream length
+        Assert.Equal(512, hybridStream.Length);
+    }
+
+    [Fact]
+    public async Task When_WritingDataMoreThenSizeThreshold_Then_FirstStreamIsNotFlushedAndDataIsWrittenToSecondStream()
+    {
+        // arrange - hybrid stream with size threshold
+        const int sizeThreshold = 1024;
+        using var firstStream = new MemoryStream();
+        using var secondStream = new MemoryStream();
+        await using var hybridStream = new HybridStream(firstStream, secondStream, new HybridStreamOptions
+        {
+            SizeThreshold = sizeThreshold
+        });
+
+        // arrange - data flushed event args
+        HybridStream.DataFlushedEventArgs dataFlushedEventArgs = null;
+        hybridStream.DataFlushed += (_, e) => dataFlushedEventArgs = e;
+
+        // arrange - data of 2048 bytes to write
+        var data = new byte[2048];
+        Array.Fill<byte>(data, 1);
+
+        // act - write data more than size threshold triggering flush to second stream
+        await hybridStream.WriteAsync(data);
+
+        // assert - data flushed event args is null as first stream was empty
+        Assert.Null(dataFlushedEventArgs);
+        
+        // assert - first stream has no data
+        Assert.Equal(0, firstStream.Length);
+
+        // assert - data flushed event args is null (first stream was empty)
+        Assert.Null(dataFlushedEventArgs);
+        
+        // assert - second stream all data
+        Assert.Equal(2048, secondStream.Length);
+
+        // assert - hybrid stream length is same as data written
+        Assert.Equal(2048, hybridStream.Length);
+    }
+}

--- a/src/Hst.Core/IO/HybridStream.cs
+++ b/src/Hst.Core/IO/HybridStream.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Timers;
+
+namespace Hst.Core.IO
+{
+    /// <summary>
+    /// Hybrid stream that changes from one stream to another based on size.
+    /// </summary>
+    public class HybridStream : Stream
+    {
+        private readonly Timer _timer = new Timer();
+        private DataFlushedEventArgs _dataFlushedEventArgs;
+        
+        public class DataFlushedEventArgs : EventArgs
+        {
+            public DataFlushedEventArgs(double percentComplete, long bytesProcessed, long bytesRemaining, long bytesTotal,
+                TimeSpan timeElapsed, TimeSpan timeRemaining, TimeSpan timeTotal, long bytesPerSecond)
+            {
+                PercentComplete = percentComplete;
+                BytesProcessed = bytesProcessed;
+                BytesRemaining = bytesRemaining;
+                BytesTotal = bytesTotal;
+                TimeElapsed = timeElapsed;
+                TimeRemaining = timeRemaining;
+                TimeTotal = timeTotal;
+                BytesPerSecond = bytesPerSecond;
+            }
+
+            public readonly double PercentComplete;
+            public readonly long BytesProcessed;
+            public readonly long BytesRemaining;
+            public readonly long BytesTotal;
+            public readonly TimeSpan TimeElapsed;
+            public readonly TimeSpan TimeRemaining;
+            public readonly TimeSpan TimeTotal;
+            public readonly long BytesPerSecond;
+        }
+        
+        private readonly byte[] _buffer = new byte[1024 * 1024];
+        private Stream _currentStream;
+        private readonly Stream _firstStream;
+        private readonly Stream _secondStream;
+        private readonly HybridStreamOptions _options;
+
+        public bool IsDisposed { get; private set; }
+
+        public event EventHandler<DataFlushedEventArgs> DataFlushed;
+
+        /// <summary>
+        /// Hybrid stream that changes from one stream to another based on size.
+        /// </summary>
+        /// <param name="firstStream">First stream to use.</param>
+        /// <param name="secondStream">Second stream to use.</param>
+        /// <param name="options">Hybrid stream options.</param>
+        public HybridStream(Stream firstStream, Stream secondStream, HybridStreamOptions options)
+        {
+            _firstStream = firstStream;
+            _secondStream = secondStream;
+            _options = options;
+            _currentStream = _firstStream;
+            
+            _timer.Enabled = true;
+            _timer.Interval = 1000;
+            _timer.Elapsed += SendDataFlushed;
+            _dataFlushedEventArgs = null;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _timer.Elapsed -= SendDataFlushed;
+                _timer.Stop();
+                SendDataFlushed(this, EventArgs.Empty);
+                
+                if (!_options.LeaveLayerStreamOpen)
+                {
+                    _firstStream.Close();
+                    _firstStream.Dispose();
+                }
+            
+                if (!_options.LeaveBaseStreamOpen)
+                {
+                    _secondStream.Close();
+                    _secondStream.Dispose();
+                }
+            }
+            
+            base.Dispose(disposing);
+        
+            IsDisposed = true;
+        }
+
+        private void SendDataFlushed(object sender, EventArgs args)
+        {
+            if (_dataFlushedEventArgs == null)
+            {
+                return;
+            }
+
+            DataFlushed?.Invoke(this, _dataFlushedEventArgs);
+            _dataFlushedEventArgs = null;
+        }
+        
+        private void OnDataFlushed(double percentComplete, long bytesProcessed, long bytesRemaining, long bytesTotal,
+            TimeSpan timeElapsed, TimeSpan timeRemaining, TimeSpan timeTotal, long bytesPerSecond)
+        {
+            _dataFlushedEventArgs = new DataFlushedEventArgs(percentComplete, bytesProcessed, bytesRemaining,
+                bytesTotal, timeElapsed, timeRemaining, timeTotal, bytesPerSecond);
+            
+            if (percentComplete >= 100)
+            {
+                SendDataFlushed(this, EventArgs.Empty);
+            }
+        }
+
+        private void SwitchToSecondStream()
+        {
+            // check if we need to switch to second stream
+            if (_currentStream == _secondStream)
+            {
+                return;
+            }
+
+            // if first stream is empty, switch directly to second stream
+            if (_currentStream.Length == 0)
+            {
+                _currentStream = _secondStream;
+                
+                return;
+            }
+            
+            // get current position from stream
+            var position = _currentStream.Position;
+            
+            var bytesProcessed = 0L;
+            var bytesTotal = _firstStream.Length;
+            OnDataFlushed(0, 0, bytesTotal, bytesTotal, 
+                TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0);
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            // flush first stream
+            _firstStream.Flush();
+            
+            // copy data from first to second stream
+            _firstStream.Position = 0;
+            _secondStream.Position = 0;
+            int bytesRead;
+            do
+            {
+                bytesRead = _firstStream.Read(_buffer, 0, _buffer.Length);
+                if (bytesRead > 0)
+                {
+                    _secondStream.Write(_buffer, 0, bytesRead);
+                }
+                
+                bytesProcessed += bytesRead;
+                var bytesRemaining = bytesTotal == 0 ? 0 : bytesTotal - bytesProcessed;
+                var percentComplete = bytesTotal == 0 || bytesProcessed == 0 ? 0 : Math.Round((double)100 / bytesTotal * bytesProcessed, 1);
+                var timeElapsed = stopwatch.Elapsed;
+                var timeRemaining = bytesTotal == 0 ? TimeSpan.Zero : CalculateTimeRemaining(percentComplete, timeElapsed);
+                var timeTotal = bytesTotal == 0 ? TimeSpan.Zero : timeElapsed + timeRemaining;
+                var bytesPerSecond = Convert.ToInt64(bytesProcessed / timeElapsed.TotalSeconds);
+
+                OnDataFlushed(percentComplete, bytesProcessed, bytesRemaining, bytesTotal, timeElapsed, timeRemaining,
+                    timeTotal, bytesPerSecond);
+            } while (bytesRead == _buffer.Length);
+            
+            stopwatch.Stop();
+            
+            OnDataFlushed(100, bytesProcessed, 0, bytesTotal, stopwatch.Elapsed,
+                TimeSpan.Zero, stopwatch.Elapsed, 0);
+            
+            // switch to second stream
+            _currentStream = _secondStream;
+            
+            // set stream position
+            _currentStream.Position = position;
+        }
+
+        private static TimeSpan CalculateTimeRemaining(double percentComplete, TimeSpan timeElapsed)
+        {
+            return percentComplete > 0
+                ? TimeSpan.FromMilliseconds(timeElapsed.TotalMilliseconds / percentComplete *
+                                            (100 - percentComplete))
+                : TimeSpan.Zero;
+        }
+        
+        public override void Flush()
+        {
+            _currentStream.Flush();
+            
+            if (_currentStream.Length > _options.SizeThreshold)
+            {
+                SwitchToSecondStream();
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_currentStream.Position + count > _options.SizeThreshold)
+            {
+                SwitchToSecondStream();
+            }
+                
+            return _currentStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (_currentStream == _secondStream)
+            {
+                return _currentStream.Seek(offset, origin);
+            }
+            
+            bool switchStream;
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    switchStream = offset > _options.SizeThreshold;
+                    break;
+                case SeekOrigin.Current:
+                    switchStream = _currentStream.Position + offset > _options.SizeThreshold;
+                    break;
+                case SeekOrigin.End:
+                    switchStream = _currentStream.Length + offset > _options.SizeThreshold;
+                    break;
+                default:
+                    switchStream = false;
+                    break;
+            }
+
+            if (switchStream)
+            {
+                SwitchToSecondStream();
+            }
+
+            return _currentStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            if (value > _options.SizeThreshold)
+            {
+                SwitchToSecondStream();
+            }
+
+            _currentStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (_currentStream.Position + count > _options.SizeThreshold)
+            {
+                SwitchToSecondStream();
+            }
+                
+            _currentStream.Write(buffer, offset, count);
+        }
+
+        public override bool CanRead => _currentStream.CanRead;
+        public override bool CanSeek => _currentStream.CanSeek;
+        public override bool CanWrite => _currentStream.CanWrite;
+        public override long Length => _currentStream.Length;
+        public override long Position { get => _currentStream.Position; set => _currentStream.Position = value; }
+    }
+}

--- a/src/Hst.Core/IO/HybridStreamOptions.cs
+++ b/src/Hst.Core/IO/HybridStreamOptions.cs
@@ -1,0 +1,21 @@
+namespace Hst.Core.IO
+{
+    public class HybridStreamOptions
+    {
+        /// <summary>
+        /// Leave the first stream open after disposing the hybrid stream.
+        /// </summary>
+        public bool LeaveLayerStreamOpen { get; set; } = false;
+
+        /// <summary>
+        /// Leave the second stream open after disposing the hybrid stream.
+        /// </summary>
+        public bool LeaveBaseStreamOpen { get; set; } = false;
+        
+        /// <summary>
+        /// Size threshold to switch from first stream to second stream.
+        /// Default is 512 MB.
+        /// </summary>
+        public long SizeThreshold { get; set; } = 512 * 1024 * 1024;
+    }
+}

--- a/src/Hst.Core/IO/LayeredStream.cs
+++ b/src/Hst.Core/IO/LayeredStream.cs
@@ -474,6 +474,11 @@ namespace Hst.Core.IO
                 // read block number from layer stream 
                 var blockNumberBytes = new byte[8];
 #if NETSTANDARD2_0
+                var blockNumberBytesRead = await _layerStream.ReadAsync(blockNumberBytes, 0, 8, cancellationToken);
+                if (blockNumberBytesRead != 8)
+                {
+                    throw new IOException("Failed to block number from layer during flush");
+                }
 #else
                 await _layerStream.ReadExactlyAsync(blockNumberBytes, 0, 8, cancellationToken);
 #endif


### PR DESCRIPTION
This PR adds a hybrid stream, which from one to another based on size of the stream. As an example, the hybrid stream can be used as a cache, where its created with a memory stream as the first stream, file stream as the second stream and a size threshold of 500MB. The hybrid stream will first use the memory stream and when it passes 500MB in size, the hybrid stream will copy the first stream to the second stream and continue to only use second stream.